### PR TITLE
Update README.md about platform specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,37 @@
 Oscilloscope X-Y Mode Emulator
 tested on Python 3.9
 
-download http://luis.net/projects/scope/beams_4ch.wav
+## Prerequisites
+* Python 3.9+
+* MacOS
+```shell
+brew install portaudio
+```
+* Linux (Debian/Ubuntu)
+```shell
+sudo apt install libportaudio2 libportaudiocpp0
+```
+* Windows: additional actions are not required
 
+## Setup
+1. Download http://luis.net/projects/scope/beams_4ch.wav
+2. Run
+```shell
 python3 -m venv venv
-
+```
+Mac/Linux:
+```shell
 source venv/bin/activate
+```
+Windows:
+```shell
+venv\Scripts\activate.bat
+```
+```shell
+pip install -r requirements.txt
+```
 
-(venv) pip install -r requirements.txt
-
-(venv) python3 ./scope_emu.py -i beams_4ch.wav -g False -l True
+## Run demo
+```shell
+python3 ./scope_emu.py -i beams_4ch.wav -g False -l True
+```


### PR DESCRIPTION
Fix for:
```
$ pip install -r requirements.txt
Collecting pyaudio>=0.2.14 (from -r requirements.txt (line 1))
  Downloading PyAudio-0.2.14.tar.gz (47 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting pygame>=2.5.2 (from -r requirements.txt (line 2))
  Downloading pygame-2.6.1-cp313-cp313-macosx_11_0_arm64.whl.metadata (12 kB)
Collecting numpy>=1.26.4 (from -r requirements.txt (line 3))
  Using cached numpy-2.3.2-cp313-cp313-macosx_14_0_arm64.whl.metadata (62 kB)
Downloading pygame-2.6.1-cp313-cp313-macosx_11_0_arm64.whl (12.4 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12.4/12.4 MB 13.9 MB/s eta 0:00:00
Using cached numpy-2.3.2-cp313-cp313-macosx_14_0_arm64.whl (5.1 MB)
Building wheels for collected packages: pyaudio
  Building wheel for pyaudio (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for pyaudio (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [27 lines of output]
      /private/var/folders/0c/yl1z393d0r936b7vgf9_9x7h0000gn/T/pip-build-env-mmnf893c/overlay/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:
      
              License :: OSI Approved :: MIT License
      
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      
      !!
        self._finalize_license_expression()
      running bdist_wheel
      running build
      running build_py
      creating build/lib.macosx-10.13-universal2-cpython-313/pyaudio
      copying src/pyaudio/__init__.py -> build/lib.macosx-10.13-universal2-cpython-313/pyaudio
      running build_ext
      building 'pyaudio._portaudio' extension
      creating build/temp.macosx-10.13-universal2-cpython-313/src/pyaudio
      clang -fno-strict-overflow -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -O3 -Wall -arch arm64 -arch x86_64 -I/opt/homebrew/opt/openssl@3/include -DMACOS=1 -I/usr/local/include -I/usr/include -I/opt/homebrew/include -I/Users/kriadov/GitHub/scope_emu_demo/venv/include -I/Library/Frameworks/Python.framework/Versions/3.13/include/python3.13 -c src/pyaudio/device_api.c -o build/temp.macosx-10.13-universal2-cpython-313/src/pyaudio/device_api.o
      src/pyaudio/device_api.c:9:10: fatal error: 'portaudio.h' file not found
          9 | #include "portaudio.h"
            |          ^~~~~~~~~~~~~
      1 error generated.
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pyaudio
Failed to build pyaudio                                                                                                                                                

[notice] A new release of pip is available: 25.1.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
ERROR: Failed to build installable wheels for some pyproject.toml based projects (pyaudio)
```